### PR TITLE
Add initial support for .NET Core

### DIFF
--- a/thiscli/project/__init__.py
+++ b/thiscli/project/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import sys
 import threading
+import fnmatch
 import click
 
 from ..util import walk_up, fail
@@ -44,6 +45,7 @@ class Project(ABC):
         from .python import PythonProject
         from .cargo import CargoProject
         from .ansible import AnsibleProject
+        from .dotnet import DotnetCoreProject
 
         project = Project.find_one_of(AutotoolsProject,
                                       MesonProject,
@@ -52,6 +54,7 @@ class Project(ABC):
                                       NodejsProject,
                                       PythonProject,
                                       CargoProject,
+                                      DotnetCoreProject,
                                       AnsibleProject)
 
         if project is None:
@@ -63,7 +66,7 @@ class Project(ABC):
     @classmethod
     def find_containing(cls, *filenames):
         for root, files in walk_up(os.getcwd()):
-            if any(filename in files for filename in filenames):
+            if any(fnmatch.filter(files, filename) for filename in filenames):
                 return cls(root)
             if '.git' in files:
                 break

--- a/thiscli/project/dotnet.py
+++ b/thiscli/project/dotnet.py
@@ -1,0 +1,25 @@
+from . import Project
+from ..env import is_env_release
+
+
+class DotnetCoreProject(Project):
+    description = '.NET Core project'
+
+    @classmethod
+    def find(cls):
+        return cls.find_containing('*.csproj')
+
+    def build(self, env):
+        if is_env_release(env):
+            self.cmd("dotnet build -c release")
+        else:
+            self.cmd("dotnet build")
+
+    def test(self):
+        self.cmd("dotnet test")
+
+    def run(self, env):
+        if is_env_release(env):
+            self.cmd("dotnet run -c release")
+        else:
+            self.cmd("dotnet run")


### PR DESCRIPTION
Note that I added some basic support for filename matching to `find_containing` by using [fnmatch](https://docs.python.org/2/library/fnmatch.html#fnmatch.filter).